### PR TITLE
ENG-8462: Fix hard-coded lambda versions

### DIFF
--- a/variables_deployment.tf
+++ b/variables_deployment.tf
@@ -1,7 +1,7 @@
 variable "lambda_code_version" {
   description = "Version of the Sidecar Custom Certificate Lambda code."
   type        = string
-  default     = "v0.3.0"
+  default     = "v1.0.0"
 }
 
 variable "lambda_code_s3_bucket" {


### PR DESCRIPTION
## Description of the change

By default, it should point to `v1.0.0` of the lambda.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] Jira issue referenced in commit message and/or PR title

### Testing
NA